### PR TITLE
docs: fixed typos here and there

### DIFF
--- a/src/patterns/RenderProps/README.md
+++ b/src/patterns/RenderProps/README.md
@@ -1,6 +1,6 @@
 # Render Props
 
-In React, Render Prop's is a way to share code between Component's using a prop, often called `render`, whose value is a function. This function generally returns a React Element. This pattern allows us to dynamically declare content to render, and what state, or data, it has access to.
+In React, Render Props is a way to share code between Components using a prop, often called `render`, whose value is a function. This function generally returns a React Element. This pattern allows us to dynamically declare content to render, and what state, or data, it has access to.
 
 A commonly used library that takes advantage of the Render Props pattern is the React Router library.
 
@@ -28,10 +28,10 @@ const newProps = {
 </Switch>
 ```
 
-The Render Props pattern provides a way to reuse and extend functionality in a clean, succinct way. In the example above the React Router team is able to extend the functionality of the Route Component by explicitily telling it what elements to render and what data to provide.
+The Render Props pattern provides a way to reuse and extend functionality in a clean, succinct way. In the example above the React Router team is able to extend the functionality of the Route Component by explicitly telling it what elements to render and what data to provide.
 
 There are three example of Render Props in the `render/` directory.
 
 The simplest example of render props can be found in `AddText.js`. Here we're adding the ability to track input state into our Component. We define the functionality and data we want to share amongst Components of a similar type, we pass that information into a render invocation that we receive through props, and that render invocation will return a Component that contains our data and functionality from the previously defined wrapper (eg. `AddText` is used to render our `RenderProps` Component and gives it the ability to track text inputs.)
 
-For more examples or to read more about Render Props, checkout the <a href="https://reactjs.org/docs/render-props.html">React Documentation on Render Props's</a>.
+For more examples or to read more about Render Props, checkout the <a href="https://reactjs.org/docs/render-props.html">React Documentation on Render Props</a>.

--- a/src/patterns/RenderProps/render/AddText.js
+++ b/src/patterns/RenderProps/render/AddText.js
@@ -1,11 +1,11 @@
 import React, { Component } from "react";
 
-// In this component we're defining state to track and handler to interact with that state.
+// In this component we're defining state to track and a handler to interact with that state.
 // We then bundle that data, functionality, and any other content we need (eg. the style prop)
 // into a variable called decorate. When we invoke the render prop, we'll pass in our extended functionality
 // which will be added onto the Component we return from our `this.props.render` invocation.
 
-// This syntax allows us to define reusable, compact chucnks of data and functionality that can
+// This syntax allows us to define reusable, compact chunks of data and functionality that can
 // be shared with a potentially limitless number of Components.
 
 class AddText extends Component {


### PR DESCRIPTION
Fixed a few typos here and there. I think that your example is very good, even though I still have a tough time fully wrapping my mind around this pattern, it is awesome. One suggestion would be to maybe rename the RenderProps component to something else. I can't think of a succinct name, but something like ComponentToReceiveRenderProps or something like that might help the reader differentiate between what the actual component is and where the render props are actually coming from. Just a personal opinion. Otherwise, I think it is a great example of a complex pattern!