### PR TITLE
Refactor: updated styling and display

### DIFF
--- a/src/patterns/HigherOrderComp/HigherOrderComp.js
+++ b/src/patterns/HigherOrderComp/HigherOrderComp.js
@@ -51,7 +51,7 @@ class HigherOrderMouse extends Component {
     const { x, y } = this.props.mouse;
 
     return (
-      <div style={{ height: "500px" }}>
+      <div>
         <h1>
           The mouse position is ({x}, {y})
         </h1>

--- a/src/patterns/HigherOrderComp/hoc/withMouse.js
+++ b/src/patterns/HigherOrderComp/hoc/withMouse.js
@@ -22,7 +22,7 @@ const withMouse = Component => {
 
     render() {
       return (
-        <div style={{ height: "100%" }} onMouseMove={this.handleMouseMove}>
+        <div onMouseMove={this.handleMouseMove}>
           <Component {...this.props} mouse={this.state} />
         </div>
       );

--- a/src/patterns/RenderProps/RenderProps.js
+++ b/src/patterns/RenderProps/RenderProps.js
@@ -4,8 +4,16 @@ class RenderProps extends Component {
   render() {
     return (
       <div style={this.props.style}>
-        <input onChange={event => this.props.handleTextInput(event)} />
-        {this.props.textInput}
+        {this.props.textInput ? (
+          <h3>{this.props.textInput}</h3>
+        ) : (
+          <h3>Render Props Example</h3>
+        )}
+
+        <input
+          style={{ margin: " 20px auto", width: "100px" }}
+          onChange={event => this.props.handleTextInput(event)}
+        />
       </div>
     );
   }


### PR DESCRIPTION
Removed height styling tags since they moved the Render Props component out of view, also changed display of the render props to make the change more obvious. These changes are not necessary, I just felt they improved the ease of finding all components.